### PR TITLE
fix(wasm): Restrict max number of web workers up to 6

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -3,7 +3,7 @@ use wasm_bindgen_futures::JsFuture;
 use js_sys::{Math::random, Promise, WebAssembly::Global};
 use web_sys::{Request, RequestInit, RequestMode, Response, Window};
 
-const MAX_RETRIES: u8 = 5;
+const MAX_RETRIES: u8 = 10;
 
 
 async fn sleep(sleep_time: i32){
@@ -59,7 +59,7 @@ pub async fn fetch(request: &Request) -> Option<String>  {
         if retries > MAX_RETRIES {
            return None
         };
-        let wait_time = ((retries.pow(2) as f64 + random()) * 1000 as f64) as i32;
+        let wait_time = ((retries.pow(2) as f64 + random()) * 100 as f64) as i32;
         sleep(wait_time).await;
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));


### PR DESCRIPTION
This commit restricts max number of web workers up to 6 because the maximum concurrent connection to same host is 6 on chrome anyway. And this commit also fixes bug that wasm initialization fails for insufficient memory by terminating each worker when each upload process is finished.

Closes https://github.com/tkasuz/s3-signurl-uploader/issues/28